### PR TITLE
ci: fix PR Checks (core redeclare)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,8 +16,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
-            const pr = context.payload.pull_request;
+                        const pr = context.payload.pull_request;
             if (!pr) core.setFailed('No pull_request in context');
 
             const labels = (pr.labels || []).map(l => l.name);


### PR DESCRIPTION
Remove const core redeclare to fix SyntaxError in github-script.